### PR TITLE
Added Ignore Paths

### DIFF
--- a/lib/show-todo-view.coffee
+++ b/lib/show-todo-view.coffee
@@ -124,18 +124,27 @@ class ShowTodoView extends ScrollView
     # console.log('pattern', pattern)
     # console.log('regexObj', regexObj)
     return atom.project.scan regexObj, (e) ->
+      # Check against ignored paths
+      include = true
+      ignoreFromSettings = atom.config.get('todo-show.ignoreThesePaths')
 
-      #loop through the results in the file, strip out 'todo:', and allow an optional space after todo:
-      # regExMatch.matchText = regExMatch.matchText.match(regexObj)[1] for regExMatch in e.matches
-      for regExMatch in e.matches
+      for ignorePath in ignoreFromSettings
+        ignoredPath = atom.project.getPath() + ignorePath
 
-        # strip out the regex token from the found phrase (todo, fixme, etc)
-        # FIXME: I have no idea why this requires a stupid while loop. Figure it out and/or fix it.
-        while (match = regexObj.exec(regExMatch.matchText))
-          regExMatch.matchText = match[1]
+        if e.filePath.substring(0, ignoredPath.length) == ignoredPath
+          include = false
 
-      regexObject.results.push(e) # add it to the array of results for this regex
+      if include
+        # loop through the results in the file, strip out 'todo:', and allow an optional space after todo:
+        # regExMatch.matchText = regExMatch.matchText.match(regexObj)[1] for regExMatch in e.matches
+        for regExMatch in e.matches
 
+          # strip out the regex token from the found phrase (todo, fixme, etc)
+          # FIXME: I have no idea why this requires a stupid while loop. Figure it out and/or fix it.
+          while (match = regexObj.exec(regExMatch.matchText))
+            regExMatch.matchText = match[1]
+
+        regexObject.results.push(e)
 
   renderTodos: ->
     @showLoading()

--- a/lib/show-todo.coffee
+++ b/lib/show-todo.coffee
@@ -14,9 +14,13 @@ module.exports =
       'FIXMEs'
       '/FIXME:(.+$)/g'
       'TODOs' #title
-      '/TODO:(.+$)/g' 
+      '/TODO:(.+$)/g'
       'CHANGEDs'
       '/CHANGED:(.+$)/g'
+    ],
+    ignoreThesePaths: [
+      '/node_modules/'
+      '/vendor/'
     ]
 
   activate: (state) ->


### PR DESCRIPTION
Implements #6. First time touching an Atom package, so let me know if I screwed something up somewhere. Testing it with the package itself seemed to work! It's basically your first proposed solution in issue #6, but I don't even bother checking matches if the path is excluded.

I made `node_modules` and `vendor` ignored by default, not sure how we want to handle those though.
