### PR TITLE
Fixed keymap

### DIFF
--- a/keymaps/show-todo.cson
+++ b/keymaps/show-todo.cson
@@ -8,4 +8,4 @@
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
 '.workspace':
-  'ctrl-shift-t': 'show-todo:find'
+  'ctrl-shift-t': 'todo-show:find-in-project'


### PR DESCRIPTION
The keymap now uses 'todo-show:find-in-project' instead of the not-bound 'todo-show:find', allowing ctrl-shift-T to work as expected.
