### PR TITLE
End comment in JSX

### DIFF
--- a/lib/todo-model.coffee
+++ b/lib/todo-model.coffee
@@ -105,5 +105,5 @@ class TodoModel
     text.replace(startRegex, '').trim()
 
   stripCommentEnd: (text = '') ->
-    endRegex = /(\*\/|\?>|-->|#>|-}|\]\])\s*$/
+    endRegex = /(\*\/}?|\?>|-->|#>|-}|\]\])\s*$/
     text.replace(endRegex, '').trim()


### PR DESCRIPTION
In JSX comments must be enclosed in curly brackets, i.e. ```{/* TODO: some text */}```. Suggested change will support correct comment end striping.