### PR TITLE
Exclude non-essential files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/screenshots    export-ignore
+/spec           export-ignore
+/.eslintrc      export-ignore
+/.gitattributes export-ignore
+/.gitignore     export-ignore
+/.travis.yml    export-ignore


### PR DESCRIPTION
This way the users of this package doesn't have to download non-essential files which aren't necessary for the package to function. This will exclude files used for development such as screenshots, spec, .travis.yml, etc.